### PR TITLE
Expose the AST for more flexible usages

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -87,3 +87,41 @@ func (a *Array) Pos() int {
 func (a *Array) End() int {
 	return a.Position.End
 }
+
+type TableType uint8
+
+const (
+	TableTypeNormal TableType = iota
+	TableTypeArray
+)
+
+var tableTypes = [...]string{
+	"normal",
+	"array",
+}
+
+func (t TableType) String() string {
+	return tableTypes[t]
+}
+
+type Table struct {
+	Position Position
+	Line     int
+	Name     string
+	Fields   map[string]interface{}
+	Type     TableType
+}
+
+func (t *Table) Pos() int {
+	return t.Position.Begin
+}
+
+func (t *Table) End() int {
+	return t.Position.End
+}
+
+type KeyValue struct {
+	Key   string
+	Value Value
+	Line  int
+}

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1,5 +1,10 @@
 package ast
 
+import (
+	"strconv"
+	"time"
+)
+
 type Position struct {
 	Begin int
 	End   int
@@ -47,6 +52,10 @@ func (i *Integer) Source() string {
 	return string(i.Data)
 }
 
+func (i *Integer) Int() (int64, error) {
+	return strconv.ParseInt(i.Value, 10, 64)
+}
+
 type Float struct {
 	Position Position
 	Value    string
@@ -63,6 +72,10 @@ func (f *Float) End() int {
 
 func (f *Float) Source() string {
 	return string(f.Data)
+}
+
+func (f *Float) Float() (float64, error) {
+	return strconv.ParseFloat(f.Value, 64)
 }
 
 type Boolean struct {
@@ -83,6 +96,10 @@ func (b *Boolean) Source() string {
 	return string(b.Data)
 }
 
+func (b *Boolean) Boolean() (bool, error) {
+	return strconv.ParseBool(b.Value)
+}
+
 type Datetime struct {
 	Position Position
 	Value    string
@@ -99,6 +116,10 @@ func (d *Datetime) End() int {
 
 func (d *Datetime) Source() string {
 	return string(d.Data)
+}
+
+func (d *Datetime) Time() (time.Time, error) {
+	return time.Parse(time.RFC3339Nano, d.Value)
 }
 
 type Array struct {

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -8,11 +8,13 @@ type Position struct {
 type Value interface {
 	Pos() int
 	End() int
+	Source() string
 }
 
 type String struct {
 	Position Position
 	Value    string
+	Data     []rune
 }
 
 func (s *String) Pos() int {
@@ -23,9 +25,14 @@ func (s *String) End() int {
 	return s.Position.End
 }
 
+func (s *String) Source() string {
+	return string(s.Data)
+}
+
 type Integer struct {
 	Position Position
 	Value    string
+	Data     []rune
 }
 
 func (i *Integer) Pos() int {
@@ -36,9 +43,14 @@ func (i *Integer) End() int {
 	return i.Position.End
 }
 
+func (i *Integer) Source() string {
+	return string(i.Data)
+}
+
 type Float struct {
 	Position Position
 	Value    string
+	Data     []rune
 }
 
 func (f *Float) Pos() int {
@@ -49,9 +61,14 @@ func (f *Float) End() int {
 	return f.Position.End
 }
 
+func (f *Float) Source() string {
+	return string(f.Data)
+}
+
 type Boolean struct {
 	Position Position
 	Value    string
+	Data     []rune
 }
 
 func (b *Boolean) Pos() int {
@@ -62,9 +79,14 @@ func (b *Boolean) End() int {
 	return b.Position.End
 }
 
+func (b *Boolean) Source() string {
+	return string(b.Data)
+}
+
 type Datetime struct {
 	Position Position
 	Value    string
+	Data     []rune
 }
 
 func (d *Datetime) Pos() int {
@@ -75,9 +97,14 @@ func (d *Datetime) End() int {
 	return d.Position.End
 }
 
+func (d *Datetime) Source() string {
+	return string(d.Data)
+}
+
 type Array struct {
 	Position Position
 	Value    []Value
+	Data     []rune
 }
 
 func (a *Array) Pos() int {
@@ -86,6 +113,10 @@ func (a *Array) Pos() int {
 
 func (a *Array) End() int {
 	return a.Position.End
+}
+
+func (a *Array) Source() string {
+	return string(a.Data)
 }
 
 type TableType uint8
@@ -110,6 +141,7 @@ type Table struct {
 	Name     string
 	Fields   map[string]interface{}
 	Type     TableType
+	Data     []rune
 }
 
 func (t *Table) Pos() int {
@@ -118,6 +150,10 @@ func (t *Table) Pos() int {
 
 func (t *Table) End() int {
 	return t.Position.End
+}
+
+func (t *Table) Source() string {
+	return string(t.Data)
 }
 
 type KeyValue struct {

--- a/decode.go
+++ b/decode.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/naoina/toml/ast"
 )
@@ -242,7 +241,7 @@ func setValue(lhs reflect.Value, val ast.Value) error {
 }
 
 func setInt(fv reflect.Value, v *ast.Integer) error {
-	i, err := strconv.ParseInt(v.Value, 10, 64)
+	i, err := v.Int()
 	if err != nil {
 		return err
 	}
@@ -263,7 +262,7 @@ func setInt(fv reflect.Value, v *ast.Integer) error {
 }
 
 func setFloat(fv reflect.Value, v *ast.Float) error {
-	f, err := strconv.ParseFloat(v.Value, 64)
+	f, err := v.Float()
 	if err != nil {
 		return err
 	}
@@ -286,7 +285,7 @@ func setString(fv reflect.Value, v *ast.String) error {
 }
 
 func setBoolean(fv reflect.Value, v *ast.Boolean) error {
-	b, err := strconv.ParseBool(v.Value)
+	b, err := v.Boolean()
 	if err != nil {
 		return err
 	}
@@ -294,7 +293,7 @@ func setBoolean(fv reflect.Value, v *ast.Boolean) error {
 }
 
 func setDatetime(fv reflect.Value, v *ast.Datetime) error {
-	tm, err := time.Parse(time.RFC3339Nano, v.Value)
+	tm, err := v.Time()
 	if err != nil {
 		return err
 	}

--- a/decode.go
+++ b/decode.go
@@ -61,53 +61,6 @@ type Unmarshaler interface {
 	UnmarshalTOML([]byte) error
 }
 
-// Given TOML, return an AST representation. The toplevel is represented
-// by a table.
-func Parse(data []byte) (*ast.Table, error) {
-	d := &decodeState{p: &tomlParser{Buffer: string(data)}}
-	d.init()
-
-	if err := d.parse(); err != nil {
-		return nil, err
-	}
-
-	return d.p.toml.table, nil
-}
-
-type decodeState struct {
-	p *tomlParser
-}
-
-func (d *decodeState) init() {
-	d.p.Init()
-	d.p.toml.init()
-}
-
-func (d *decodeState) parse() error {
-	if err := d.p.Parse(); err != nil {
-		if err, ok := err.(*parseError); ok {
-			return fmt.Errorf("toml: line %d: parse error", err.Line())
-		}
-		return err
-	}
-	return d.execute()
-}
-
-func (d *decodeState) execute() (err error) {
-	defer func() {
-		e := recover()
-		if e != nil {
-			cerr, ok := e.(convertError)
-			if !ok {
-				panic(e)
-			}
-			err = cerr.err
-		}
-	}()
-	d.p.Execute()
-	return nil
-}
-
 // UnmarshalTable applies the contents of an ast.Table to the value pointed at by v.
 //
 // UnmarshalTable will mapped to v that according to following rules:

--- a/parse.go
+++ b/parse.go
@@ -1,0 +1,54 @@
+package toml
+
+import (
+	"fmt"
+
+	"github.com/naoina/toml/ast"
+)
+
+// Given TOML, return an AST representation. The toplevel is represented
+// by a table.
+func Parse(data []byte) (*ast.Table, error) {
+	d := &parseState{p: &tomlParser{Buffer: string(data)}}
+	d.init()
+
+	if err := d.parse(); err != nil {
+		return nil, err
+	}
+
+	return d.p.toml.table, nil
+}
+
+type parseState struct {
+	p *tomlParser
+}
+
+func (d *parseState) init() {
+	d.p.Init()
+	d.p.toml.init()
+}
+
+func (d *parseState) parse() error {
+	if err := d.p.Parse(); err != nil {
+		if err, ok := err.(*parseError); ok {
+			return fmt.Errorf("toml: line %d: parse error", err.Line())
+		}
+		return err
+	}
+	return d.execute()
+}
+
+func (d *parseState) execute() (err error) {
+	defer func() {
+		e := recover()
+		if e != nil {
+			cerr, ok := e.(convertError)
+			if !ok {
+				panic(e)
+			}
+			err = cerr.err
+		}
+	}()
+	d.p.Execute()
+	return nil
+}


### PR DESCRIPTION
This is easily the best TOML parser and so I wanted to be able to expose the ast to be used in a more flexible way that having to be decoded into a struct or map.

This exposes that API by doing a couple things:

1. Move table and keyValue to the ast package and expose them
2. Change the ast value to hold their original source data to allow for "detached" usage of setUnmarshaller
3. Decouple the decoding functions from decodeState so they can be called when values are already decoded.
4. Add `Parse` and `UnmarshalTable` to allow the user to retrieve and coerce parts into values.