### PR TITLE
add UnmarshallFile convenience method

### DIFF
--- a/file.go
+++ b/file.go
@@ -5,6 +5,8 @@ import (
 	"os"
 )
 
+// UnmarshalFile parses the TOML data in file filename on disk and stores it in
+// the value pointed to by v
 func UnmarshalFile(filename string, v interface{}) error {
 	f, err := os.Open(filename)
 	if err != nil {

--- a/file.go
+++ b/file.go
@@ -1,0 +1,23 @@
+package toml
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+func UnmarshalFile(filename string, v interface{}) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	buf, err := ioutil.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	err = Unmarshal(buf, v)
+
+	return err
+}


### PR DESCRIPTION
If the most common use case is to read in the file and parse it, seems like a convenience method is a good idea.