### PR TITLE
Create explicitly defined table explicitly

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -177,6 +177,10 @@ func (t *Table) Source() string {
 	return string(t.Data)
 }
 
+func (t *Table) IsDefined() bool {
+	return t.Position != Position{}
+}
+
 type KeyValue struct {
 	Key   string
 	Value Value


### PR DESCRIPTION
Tables with same paths got merged in some cases in old code, while it
should be rejected due to duplicated definitions.

I think we should distinguish explicitly created tables from implicitly
created tables by some way. So we can detect duplicated explicitly table
creation. For now, I uses field Position in ast.Table for this purpose.

Following example is success to decode in old code, while it should be
rejected due to duplicated definitions which is not allowed by TOML
Spec.

``` toml
[super.sub]
name = "name"
[super.sub]
value = "value" # Replaces with `name = "xxx"` will got confliction by key "name"
```
