### PR TITLE
Add support for struct pointer traversal

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -74,6 +74,11 @@ type Marshaler interface {
 
 func marshal(buf []byte, prefix string, rv reflect.Value, inArray, arrayTable bool) ([]byte, error) {
 	rt := rv.Type()
+	for rt.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+		rt = rv.Type()
+	}
+
 	for i := 0; i < rv.NumField(); i++ {
 		ft := rt.Field(i)
 		if !ast.IsExported(ft.Name) {
@@ -158,6 +163,13 @@ func encodeValue(buf []byte, prefix, name string, fv reflect.Value, inArray, arr
 			return nil, err
 		}
 		return appendNewline(buf, inArray, arrayTable), nil
+	case reflect.Ptr:
+		newElem := fv.Elem()
+		if newElem.IsValid() {
+			return encodeValue(buf, prefix, name, newElem, inArray, arrayTable)
+		} else {
+			return encodeValue(buf, prefix, name, reflect.New(fv.Type().Elem()), inArray, arrayTable)
+		}
 	}
 	return nil, fmt.Errorf("toml: marshal: unsupported type %v", fv.Kind())
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -296,3 +296,35 @@ name="plantain"
 		}
 	}
 }
+
+func TestMarshalPointer(t *testing.T) {
+	type Profession struct {
+		Name       string
+		Department string
+	}
+
+	foo := struct {
+		Active     bool
+		Name       string
+		Occupation *Profession
+	}{
+		true,
+		"Foo Bar",
+		&Profession{"Professor", "CS"},
+	}
+
+	expect := `active=true
+name="Foo Bar"
+[occupation]
+name="Professor"
+department="CS"
+`
+	actual, err := toml.Marshal(&foo)
+	if err != nil {
+		t.Errorf(`Unable to marshal pointer, err was %s`, err.Error())
+	}
+
+	if !reflect.DeepEqual(string(actual), expect) {
+		t.Errorf(`Marshal(%#v); v => %#v; want %#v`, foo, string(actual), expect)
+	}
+}


### PR DESCRIPTION
This deals with two cases: where we have been provided with a pointer to
a struct in the call to Marshal(), and also where we encounter a pointer
while encoding a struct. The former case resulted in a panic (see #13),
while the latter reported that Pointer types were not supported. The
solution uses reflection to continually walk across pointers to get to
the underlying value.

Fixes #13
