### PR TITLE
Support encoding maps / disambiguate nested structs and basic values

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"sort"
 	"strconv"
 	"time"
 
@@ -163,6 +164,12 @@ func encodeValue(buf []byte, prefix, name string, fv reflect.Value, inArray, arr
 		buf := append(append(append(buf, '['), name...), ']', '\n')
 
 		keys := fv.MapKeys()
+		sortedKeys := make([]string, 0, len(keys))
+		for _, key := range keys {
+			sortedKeys = append(sortedKeys, key.String())
+		}
+		sort.Strings(sortedKeys)
+
 		var err error
 		for _, key := range keys {
 			buf, err = encodeValue(buf, prefix, key.String(), fv.MapIndex(key), inArray, arrayTable)

--- a/encode.go
+++ b/encode.go
@@ -176,12 +176,19 @@ func encodeValue(buf []byte, prefix, name string, fv reflect.Value, inArray, arr
 		keys := fv.MapKeys()
 		sortedKeys := make([]string, 0, len(keys))
 		for _, key := range keys {
-			sortedKeys = append(sortedKeys, key.String())
+			var keyStr string
+			switch key.Interface().(type) {
+			case fmt.Stringer:
+				keyStr = key.String()
+			case string:
+				keyStr = key.Interface().(string)
+			}
+			sortedKeys = append(sortedKeys, keyStr)
 		}
 		sort.Strings(sortedKeys)
 
 		var err error
-		for _, key := range keys {
+		for _, key := range sortedKeys {
 			buf, err = encodeValue(buf, name, key.String(), fv.MapIndex(key), inArray, arrayTable)
 			if err != nil {
 				return nil, err

--- a/encode.go
+++ b/encode.go
@@ -172,7 +172,7 @@ func encodeValue(buf []byte, prefix, name string, fv reflect.Value, inArray, arr
 
 		var err error
 		for _, key := range keys {
-			buf, err = encodeValue(buf, prefix, key.String(), fv.MapIndex(key), inArray, arrayTable)
+			buf, err = encodeValue(buf, name, key.String(), fv.MapIndex(key), inArray, arrayTable)
 			if err != nil {
 				return nil, err
 			}

--- a/encode.go
+++ b/encode.go
@@ -75,6 +75,9 @@ type Marshaler interface {
 
 func marshal(buf []byte, prefix string, rv reflect.Value, inArray, arrayTable bool) ([]byte, error) {
 	rt := rv.Type()
+	tableBuf := make([]byte, 0)
+	valueBuf := make([]byte, 0)
+
 	for i := 0; i < rv.NumField(); i++ {
 		ft := rt.Field(i)
 		if !ast.IsExported(ft.Name) {
@@ -95,11 +98,18 @@ func marshal(buf []byte, prefix string, rv reflect.Value, inArray, arrayTable bo
 			}
 		}
 		var err error
-		if buf, err = encodeValue(buf, prefix, colName, fv, inArray, arrayTable); err != nil {
-			return nil, err
+		switch fv.Kind() {
+		case reflect.Struct, reflect.Map, reflect.Slice:
+			if tableBuf, err = encodeValue(tableBuf, prefix, colName, fv, inArray, arrayTable); err != nil {
+				return nil, err
+			}
+		default:
+			if valueBuf, err = encodeValue(valueBuf, prefix, colName, fv, inArray, arrayTable); err != nil {
+				return nil, err
+			}
 		}
 	}
-	return buf, nil
+	return append(append(buf, valueBuf...), tableBuf...), nil
 }
 
 func encodeValue(buf []byte, prefix, name string, fv reflect.Value, inArray, arrayTable bool) ([]byte, error) {

--- a/encode.go
+++ b/encode.go
@@ -158,6 +158,19 @@ func encodeValue(buf []byte, prefix, name string, fv reflect.Value, inArray, arr
 			return nil, err
 		}
 		return appendNewline(buf, inArray, arrayTable), nil
+	case reflect.Map:
+		name := tableName(prefix, name)
+		buf := append(append(append(buf, '['), name...), ']', '\n')
+
+		keys := fv.MapKeys()
+		var err error
+		for _, key := range keys {
+			buf, err = encodeValue(buf, prefix, key.String(), fv.MapIndex(key), inArray, arrayTable)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return buf, nil
 	}
 	return nil, fmt.Errorf("toml: marshal: unsupported type %v", fv.Kind())
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -35,6 +35,9 @@ func TestMarshal(t *testing.T) {
 		{struct {
 			Name string `toml:",omitempty"`
 		}{""}, ""},
+		{struct {
+			Name map[string]string `toml:"name"`
+		}{map[string]string{"foo": "bar", "baz": "quux"}}, "[name]\nfoo=\"bar\"\nbaz=\"quux\"\n"},
 	} {
 		b, err := toml.Marshal(v.v)
 		var actual interface{} = err

--- a/encode_test.go
+++ b/encode_test.go
@@ -9,6 +9,11 @@ import (
 )
 
 func TestMarshal(t *testing.T) {
+	type iceCreamPreference struct {
+		Flavor string
+		Scoops int
+	}
+
 	for _, v := range []struct {
 		v      interface{}
 		expect string
@@ -38,6 +43,9 @@ func TestMarshal(t *testing.T) {
 		{struct {
 			Name map[string]string `toml:"name"`
 		}{map[string]string{"foo": "bar", "baz": "quux"}}, "[name]\nfoo=\"bar\"\nbaz=\"quux\"\n"},
+		{struct {
+			Preferences map[string]iceCreamPreference `toml:"preferences"`
+		}{map[string]iceCreamPreference{"tim": iceCreamPreference{"Vanilla", 3}}}, "[preferences]\n[tim]\nflavor=\"Vanilla\"\nscoops=3\n"},
 	} {
 		b, err := toml.Marshal(v.v)
 		var actual interface{} = err

--- a/encode_test.go
+++ b/encode_test.go
@@ -42,7 +42,7 @@ func TestMarshal(t *testing.T) {
 		}{""}, ""},
 		{struct {
 			Name map[string]string `toml:"name"`
-		}{map[string]string{"foo": "bar", "baz": "quux"}}, "[name]\nfoo=\"bar\"\nbaz=\"quux\"\n"},
+		}{map[string]string{"foo": "bar", "baz": "quux"}}, "[name]\nbaz=\"quux\"\nfoo=\"bar\"\n"},
 		{struct {
 			Preferences map[string]iceCreamPreference `toml:"preferences"`
 		}{map[string]iceCreamPreference{"tim": iceCreamPreference{"Vanilla", 3}}}, "[preferences]\n[preferences.tim]\nflavor=\"Vanilla\"\nscoops=3\n"},

--- a/encode_test.go
+++ b/encode_test.go
@@ -314,14 +314,27 @@ func TestMarshal_MixedStructMap(t *testing.T) {
 		Y int
 	}
 
+	type menuItem struct {
+		Name  string
+		Price int
+	}
+
 	type store struct {
 		StoreName string
 		Locations map[string]location
+		Cuisine   string
+		Menu      []menuItem
 	}
+
 	foo := store{
 		"Arby's",
 		map[string]location{
 			"Boston": location{1, 2},
+		},
+		"American",
+		[]menuItem{
+			menuItem{"Burger", 12},
+			menuItem{"Fries", 4},
 		},
 	}
 
@@ -331,10 +344,17 @@ func TestMarshal_MixedStructMap(t *testing.T) {
 	}
 
 	expect := `store_name="Arby's"
+cuisine="American"
 [locations]
 [locations.Boston]
 x=1
 y=2
+[[menu]]
+name="Burger"
+price=12
+[[menu]]
+name="Fries"
+price=4
 `
 
 	if string(str) != expect {


### PR DESCRIPTION
This add support for encoding maps. It makes the assumption that map keys are either `strings` or `fmt.Stringer`s. Keys are sorted prior to encoding to ensure consistent ordering.

As part of this, I ran into issues where a map or struct nested within the struct I was trying to marshal would have its values confused with values found in the parent struct (see #12). Basically this contrived example:

``` go
type User struct {
  Preferences map[string]string
  Name string
}

tim := User{
  "Tim",
  map[string]string{
    "ice_cream": "vanilla",
  }
}

out, err := toml.Marshal(tim)
```

Would produce TOML that looks something like this:

``` toml
[user]
[user.Preferences]
ice_cream="vanilla"
name="Tim"
```

When the "name" key-value pair belongs under `[user]`. This patch writes simple values and nested structs / maps / slices to separate buffers in `marshal` and then writes them back in an unambiguous order (basic values first, then nested objects).

Fixes #11 
Fixes #12
