### PR TITLE
Log undefined config options instead of erroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TOML parser and encoder library for Golang [![Build Status](https://travis-ci.org/naoina/toml.png?branch=master)](https://travis-ci.org/naoina/toml)
+# TOML parser and encoder library for Golang [![Build Status](https://travis-ci.org/influxdata/toml.png?branch=master)](https://travis-ci.org/influxdata/toml)
 
 [TOML](https://github.com/toml-lang/toml) parser and encoder library for [Golang](http://golang.org/).
 
@@ -6,7 +6,7 @@ This library is compatible with TOML version [v0.4.0](https://github.com/toml-la
 
 ## Installation
 
-    go get -u github.com/naoina/toml
+    go get -u github.com/influxdata/toml
 
 ## Usage
 
@@ -58,7 +58,7 @@ import (
     "os"
     "time"
 
-    "github.com/naoina/toml"
+    "github.com/influxdata/toml"
 )
 
 type tomlConfig struct {
@@ -357,7 +357,7 @@ func (d *Duration) UnmarshalTOML(data []byte) error {
 
 ## API documentation
 
-See [Godoc](http://godoc.org/github.com/naoina/toml).
+See [Godoc](http://godoc.org/github.com/influxdata/toml).
 
 ## License
 

--- a/_example/main.go
+++ b/_example/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/naoina/toml"
+	"github.com/influxdata/toml"
 )
 
 type tomlConfig struct {

--- a/decode.go
+++ b/decode.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/naoina/toml/ast"
+	"github.com/influxdata/toml/ast"
 )
 
 const (

--- a/decode_bench_test.go
+++ b/decode_bench_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/naoina/toml"
+	"github.com/influxdata/toml"
 )
 
 func BenchmarkUnmarshal(b *testing.B) {

--- a/decode_test.go
+++ b/decode_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/naoina/toml"
+	"github.com/influxdata/toml"
 )
 
 const (

--- a/encode.go
+++ b/encode.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	tagOmitempty = "omitempty"
+	tagDocName   = "doc"
 	tagSkip      = "-"
 )
 
@@ -89,6 +90,8 @@ func marshal(buf []byte, prefix string, rv reflect.Value, inArray, arrayTable bo
 			continue
 		}
 		colName, rest := extractTag(rt.Field(i).Tag.Get(fieldTagName))
+		docStr := rt.Field(i).Tag.Get(tagDocName)
+
 		if colName == tagSkip {
 			continue
 		}
@@ -105,11 +108,11 @@ func marshal(buf []byte, prefix string, rv reflect.Value, inArray, arrayTable bo
 		var err error
 		switch fv.Kind() {
 		case reflect.Struct, reflect.Map, reflect.Slice:
-			if tableBuf, err = encodeValue(tableBuf, prefix, colName, fv, inArray, arrayTable); err != nil {
+			if tableBuf, err = encodeValue(tableBuf, prefix, colName, fv, inArray, arrayTable, docStr); err != nil {
 				return nil, err
 			}
 		default:
-			if valueBuf, err = encodeValue(valueBuf, prefix, colName, fv, inArray, arrayTable); err != nil {
+			if valueBuf, err = encodeValue(valueBuf, prefix, colName, fv, inArray, arrayTable, docStr); err != nil {
 				return nil, err
 			}
 		}
@@ -117,28 +120,28 @@ func marshal(buf []byte, prefix string, rv reflect.Value, inArray, arrayTable bo
 	return append(append(buf, valueBuf...), tableBuf...), nil
 }
 
-func encodeValue(buf []byte, prefix, name string, fv reflect.Value, inArray, arrayTable bool) ([]byte, error) {
+func encodeValue(buf []byte, prefix, name string, fv reflect.Value, inArray, arrayTable bool, doc string) ([]byte, error) {
 	switch t := fv.Interface().(type) {
 	case Marshaler:
 		b, err := t.MarshalTOML()
 		if err != nil {
 			return nil, err
 		}
-		return appendNewline(append(appendKey(buf, name, inArray, arrayTable), b...), inArray, arrayTable), nil
+		return appendNewline(appendDocInline(append(appendKey(buf, name, inArray, arrayTable), b...), doc), inArray, arrayTable), nil
 	case time.Time:
-		return appendNewline(encodeTime(appendKey(buf, name, inArray, arrayTable), t), inArray, arrayTable), nil
+		return appendNewline(appendDocInline(encodeTime(appendKey(buf, name, inArray, arrayTable), t), doc), inArray, arrayTable), nil
 	}
 	switch fv.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return appendNewline(encodeInt(appendKey(buf, name, inArray, arrayTable), fv.Int()), inArray, arrayTable), nil
+		return appendNewline(appendDocInline(encodeInt(appendKey(buf, name, inArray, arrayTable), fv.Int()), doc), inArray, arrayTable), nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return appendNewline(encodeUint(appendKey(buf, name, inArray, arrayTable), fv.Uint()), inArray, arrayTable), nil
+		return appendNewline(appendDocInline(encodeUint(appendKey(buf, name, inArray, arrayTable), fv.Uint()), doc), inArray, arrayTable), nil
 	case reflect.Float32, reflect.Float64:
-		return appendNewline(encodeFloat(appendKey(buf, name, inArray, arrayTable), fv.Float()), inArray, arrayTable), nil
+		return appendNewline(appendDocInline(encodeFloat(appendKey(buf, name, inArray, arrayTable), fv.Float()), doc), inArray, arrayTable), nil
 	case reflect.Bool:
-		return appendNewline(encodeBool(appendKey(buf, name, inArray, arrayTable), fv.Bool()), inArray, arrayTable), nil
+		return appendNewline(appendDocInline(encodeBool(appendKey(buf, name, inArray, arrayTable), fv.Bool()), doc), inArray, arrayTable), nil
 	case reflect.String:
-		return appendNewline(encodeString(appendKey(buf, name, inArray, arrayTable), fv.String()), inArray, arrayTable), nil
+		return appendNewline(appendDocInline(encodeString(appendKey(buf, name, inArray, arrayTable), fv.String()), doc), inArray, arrayTable), nil
 	case reflect.Slice, reflect.Array:
 		ft := fv.Type().Elem()
 		for ft.Kind() == reflect.Ptr {
@@ -160,13 +163,16 @@ func encodeValue(buf []byte, prefix, name string, fv reflect.Value, inArray, arr
 			if i != 0 {
 				buf = append(buf, ',')
 			}
-			if buf, err = encodeValue(buf, prefix, name, fv.Index(i), true, false); err != nil {
+			if buf, err = encodeValue(buf, prefix, name, fv.Index(i), true, false, doc); err != nil {
 				return nil, err
 			}
 		}
-		return appendNewline(append(buf, ']'), inArray, arrayTable), nil
+		return appendNewline(appendDocInline(append(buf, ']'), doc), inArray, arrayTable), nil
 	case reflect.Struct:
 		name := tableName(prefix, name)
+		if doc != "" {
+			buf = appendNewline(appendDoc(buf, doc), false, false)
+		}
 		return marshal(append(append(append(buf, '['), name...), ']', '\n'), name, fv, inArray, arrayTable)
 	case reflect.Interface:
 		var err error
@@ -177,9 +183,9 @@ func encodeValue(buf []byte, prefix, name string, fv reflect.Value, inArray, arr
 	case reflect.Ptr:
 		newElem := fv.Elem()
 		if newElem.IsValid() {
-			return encodeValue(buf, prefix, name, newElem, inArray, arrayTable)
+			return encodeValue(buf, prefix, name, newElem, inArray, arrayTable, doc)
 		} else {
-			return encodeValue(buf, prefix, name, reflect.New(fv.Type().Elem()), inArray, arrayTable)
+			return encodeValue(buf, prefix, name, reflect.New(fv.Type().Elem()), inArray, arrayTable, doc)
 		}
 	case reflect.Map:
 		name := tableName(prefix, name)
@@ -194,7 +200,7 @@ func encodeValue(buf []byte, prefix, name string, fv reflect.Value, inArray, arr
 
 		var err error
 		for _, key := range keys {
-			buf, err = encodeValue(buf, name, key.String(), fv.MapIndex(key), inArray, arrayTable)
+			buf, err = encodeValue(buf, name, key.String(), fv.MapIndex(key), inArray, arrayTable, doc)
 			if err != nil {
 				return nil, err
 			}
@@ -202,6 +208,18 @@ func encodeValue(buf []byte, prefix, name string, fv reflect.Value, inArray, arr
 		return buf, nil
 	}
 	return nil, fmt.Errorf("toml: marshal: unsupported type %v", fv.Kind())
+}
+
+func appendDocInline(buf []byte, doc string) []byte {
+	if doc != "" {
+		return append(append(append(append(buf, ' '), '#'), ' '), doc...)
+	} else {
+		return buf
+	}
+}
+
+func appendDoc(buf []byte, doc string) []byte {
+	return appendDocInline(buf, doc)[1:]
 }
 
 func appendKey(buf []byte, key string, inArray, arrayTable bool) []byte {

--- a/encode.go
+++ b/encode.go
@@ -194,13 +194,20 @@ func encodeValue(buf []byte, prefix, name string, fv reflect.Value, inArray, arr
 		keys := fv.MapKeys()
 		sortedKeys := make([]string, 0, len(keys))
 		for _, key := range keys {
-			sortedKeys = append(sortedKeys, key.String())
+			var keyStr string
+			switch key.Interface().(type) {
+			case fmt.Stringer:
+				keyStr = key.String()
+			case string:
+				keyStr = key.Interface().(string)
+			}
+			sortedKeys = append(sortedKeys, keyStr)
 		}
 		sort.Strings(sortedKeys)
 
 		var err error
-		for _, key := range keys {
-			buf, err = encodeValue(buf, name, key.String(), fv.MapIndex(key), inArray, arrayTable, doc)
+		for _, key := range sortedKeys {
+			buf, err = encodeValue(buf, name, key, fv.MapIndex(reflect.ValueOf(key)), inArray, arrayTable, doc)
 			if err != nil {
 				return nil, err
 			}

--- a/encode.go
+++ b/encode.go
@@ -74,6 +74,11 @@ type Marshaler interface {
 
 func marshal(buf []byte, prefix string, rv reflect.Value, inArray, arrayTable bool) ([]byte, error) {
 	rt := rv.Type()
+	for rt.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+		rt = rv.Type()
+	}
+
 	for i := 0; i < rv.NumField(); i++ {
 		ft := rt.Field(i)
 		if !ast.IsExported(ft.Name) {
@@ -158,6 +163,13 @@ func encodeValue(buf []byte, prefix, name string, fv reflect.Value, inArray, arr
 			return nil, err
 		}
 		return appendNewline(buf, inArray, arrayTable), nil
+	case reflect.Ptr:
+		newElem := fv.Elem()
+		if newElem.IsValid() {
+			return encodeValue(buf, prefix, name, newElem, inArray, arrayTable)
+		} else {
+			return encodeValue(buf, prefix, name, reflect.New(fv.Type().Elem()), inArray, arrayTable)
+		}
 	}
 	return nil, fmt.Errorf("toml: marshal: unsupported type %v", fv.Kind())
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -9,6 +9,11 @@ import (
 )
 
 func TestMarshal(t *testing.T) {
+	type iceCreamPreference struct {
+		Flavor string
+		Scoops int
+	}
+
 	for _, v := range []struct {
 		v      interface{}
 		expect string
@@ -35,6 +40,12 @@ func TestMarshal(t *testing.T) {
 		{struct {
 			Name string `toml:",omitempty"`
 		}{""}, ""},
+		{struct {
+			Name map[string]string `toml:"name"`
+		}{map[string]string{"foo": "bar", "baz": "quux"}}, "[name]\nfoo=\"bar\"\nbaz=\"quux\"\n"},
+		{struct {
+			Preferences map[string]iceCreamPreference `toml:"preferences"`
+		}{map[string]iceCreamPreference{"tim": iceCreamPreference{"Vanilla", 3}}}, "[preferences]\n[preferences.tim]\nflavor=\"Vanilla\"\nscoops=3\n"},
 	} {
 		b, err := toml.Marshal(v.v)
 		var actual interface{} = err
@@ -326,5 +337,66 @@ department="CS"
 
 	if !reflect.DeepEqual(string(actual), expect) {
 		t.Errorf(`Marshal(%#v); v => %#v; want %#v`, foo, string(actual), expect)
+	}
+}
+
+func TestMarshal_MixedStructMap(t *testing.T) {
+	type location struct {
+		X int
+		Y int
+	}
+
+	type menuItem struct {
+		Name  string
+		Price int
+	}
+
+	type store struct {
+		StoreName string
+		Locations map[string]location
+		Cuisine   string
+		Menu      []menuItem
+	}
+
+	foo := store{
+		"Arby's",
+		map[string]location{
+			"Boston": location{1, 2},
+		},
+		"American",
+		[]menuItem{
+			menuItem{"Burger", 12},
+			menuItem{"Fries", 4},
+		},
+	}
+
+	str, err := toml.Marshal(foo)
+	if err != nil {
+		t.Errorf(`Error marshalling example: %s`, err.Error())
+	}
+
+	expect := `store_name="Arby's"
+cuisine="American"
+[locations]
+[locations.Boston]
+x=1
+y=2
+[[menu]]
+name="Burger"
+price=12
+[[menu]]
+name="Fries"
+price=4
+`
+
+	if string(str) != expect {
+		t.Errorf(`Marshal => %#v; want %#v`, string(str), expect)
+	}
+
+	var out store
+	toml.Unmarshal(str, &out)
+
+	if !reflect.DeepEqual(out, foo) {
+		t.Errorf(`Unmarshal => %#v; want %#v`, out, foo)
 	}
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -296,3 +296,35 @@ name="plantain"
 		}
 	}
 }
+
+func TestMarshalPointer(t *testing.T) {
+	type Profession struct {
+		Name       string
+		Department string
+	}
+
+	foo := struct {
+		Active     bool
+		Name       string
+		Occupation *Profession
+	}{
+		true,
+		"Foo Bar",
+		&Profession{"Professor", "CS"},
+	}
+
+	expect := `active=true
+name="Foo Bar"
+[occupation]
+name="Professor"
+department="CS"
+`
+	actual, err := toml.Marshal(&foo)
+	if err != nil {
+		t.Errorf(`Unable to marshal pointer, err was %s`, err.Error())
+	}
+
+	if !reflect.DeepEqual(string(actual), expect) {
+		t.Errorf(`Marshal(%#v); v => %#v; want %#v`, foo, string(actual), expect)
+	}
+}

--- a/encode_test.go
+++ b/encode_test.go
@@ -42,7 +42,7 @@ func TestMarshal(t *testing.T) {
 		}{""}, ""},
 		{struct {
 			Name map[string]string `toml:"name"`
-		}{map[string]string{"foo": "bar", "baz": "quux"}}, "[name]\nfoo=\"bar\"\nbaz=\"quux\"\n"},
+		}{map[string]string{"foo": "bar", "baz": "quux"}}, "[name]\nbaz=\"quux\"\nfoo=\"bar\"\n"},
 		{struct {
 			Preferences map[string]iceCreamPreference `toml:"preferences"`
 		}{map[string]iceCreamPreference{"tim": iceCreamPreference{"Vanilla", 3}}}, "[preferences]\n[preferences.tim]\nflavor=\"Vanilla\"\nscoops=3\n"},

--- a/encode_test.go
+++ b/encode_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/naoina/toml"
+	"github.com/influxdata/toml"
 )
 
 func TestMarshal(t *testing.T) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -46,6 +46,9 @@ func TestMarshal(t *testing.T) {
 		{struct {
 			Preferences map[string]iceCreamPreference `toml:"preferences"`
 		}{map[string]iceCreamPreference{"tim": iceCreamPreference{"Vanilla", 3}}}, "[preferences]\n[preferences.tim]\nflavor=\"Vanilla\"\nscoops=3\n"},
+		{struct {
+			Name string `toml:"name" doc:"The name of the person"`
+		}{"bob"}, "name=\"bob\" # The name of the person\n"},
 	} {
 		b, err := toml.Marshal(v.v)
 		var actual interface{} = err

--- a/parse.go
+++ b/parse.go
@@ -3,7 +3,7 @@ package toml
 import (
 	"fmt"
 
-	"github.com/naoina/toml/ast"
+	"github.com/influxdata/toml/ast"
 )
 
 // Parse returns an AST representation of TOML.

--- a/parse.peg.go
+++ b/parse.peg.go
@@ -238,7 +238,7 @@ type element struct {
 /* ${@} bit structure for abstract syntax tree */
 type token16 struct {
 	pegRule
-	begin, end, next int16
+	begin, end, next int32
 }
 
 func (t *token16) isZero() bool {
@@ -299,7 +299,7 @@ func (t *tokens16) Order() [][]token16 {
 
 	for i, token := range t.tree {
 		depth := token.next
-		token.next = int16(i)
+		token.next = int32(i)
 		ordered[depth][depths[depth]] = token
 		depths[depth]++
 	}
@@ -341,7 +341,7 @@ func (t *tokens16) PreOrder() (<-chan state16, [][]token16) {
 		depths, state, depth := make([]int16, len(ordered)), 0, 1
 		write := func(t token16, leaf bool) {
 			S := states[state]
-			state, S.pegRule, S.begin, S.end, S.next, S.leaf = (state+1)%8, t.pegRule, t.begin, t.end, int16(depth), leaf
+			state, S.pegRule, S.begin, S.end, S.next, S.leaf = (state+1)%8, t.pegRule, t.begin, t.end, int32(depth), leaf
 			copy(S.depths, depths)
 			s <- S
 		}
@@ -456,7 +456,7 @@ func (t *tokens16) PrintSyntaxTree(buffer string) {
 }
 
 func (t *tokens16) Add(rule pegRule, begin, end, depth, index int) {
-	t.tree[index] = token16{pegRule: rule, begin: int16(begin), end: int16(end), next: int16(depth)}
+	t.tree[index] = token16{pegRule: rule, begin: int32(begin), end: int32(end), next: int32(depth)}
 }
 
 func (t *tokens16) Tokens() <-chan token32 {


### PR DESCRIPTION
Instead of erroring out the Unmarshal process when an extraneous config option has been found log it and continue.

Not sure if we want to make this kinds of changes to our fork, but we need to be able to ignore extraneous config one way or the other.

@jwilder @timraymond 