### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Then above TOML will mapping to `tomlConfig` struct using `toml.Unmarshal`.
 package main
 
 import (
-    "io/ioutil"
     "os"
     "time"
 


### PR DESCRIPTION
  In the example, "io/ioutil" package is unused.