### PR TITLE
toml: implement Unwrap for LineError

### DIFF
--- a/error.go
+++ b/error.go
@@ -22,6 +22,10 @@ func (err *LineError) Error() string {
 	return fmt.Sprintf("line %d: %s%v", err.Line, field, err.Err)
 }
 
+func (err *LineError) Unwrap() error {
+	return err.Err
+}
+
 func lineError(line int, err error) error {
 	if err == nil {
 		return nil


### PR DESCRIPTION
https://pkg.go.dev/errors#Unwrap

it is really nice, to find the reason for a own implemented `UnmarshalText`